### PR TITLE
[SELS-TASK] [BE]- Enable Authguards for the Create a category Endpoint

### DIFF
--- a/backend/src/categories/categories.module.ts
+++ b/backend/src/categories/categories.module.ts
@@ -7,10 +7,17 @@ import { Words } from './words';
 import { Choices } from './choices';
 import { WordsService } from './words.service';
 import { ChoicesService } from './choices.service';
+import { JwtModule} from '@nestjs/jwt';
+import { User } from 'src/user/user';
+import { UserService } from 'src/user/user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Category, Words, Choices])],
+  imports: [JwtModule.register({
+    secret: 'secret',
+    signOptions: { expiresIn: '1d' },
+  }),
+  TypeOrmModule.forFeature([Category, Words, Choices, User])],
   controllers: [CategoriesController],
-  providers: [CategoriesService, WordsService, ChoicesService],
+  providers: [CategoriesService, WordsService, ChoicesService, UserService],
 })
 export class CategoriesModule {}


### PR DESCRIPTION
**Asana** 
- https://app.asana.com/0/1206099859473777/1205840947042124/f

**[Commands]**
- `docker compose up`

**[Pre-conditions]**
1.  After running the command , you can now access the Postman and Dbeaver.
2.  Go to admin/login
3.  Go to admin/category/create
4.  Go to student/login

**[Expected Output]**
 
- [x] Display Forbidden if Student try to edit Category
- [x] Display Category deleted successfully
- [x] Display title, description, and id of the successfully created category


**[Screenshots]**

<details> 

- [x] Admin login
![image](https://github.com/framgia/sph-els-mark/assets/142192964/00f23cbe-7d0d-4f25-932f-a71e65777683)

- [x] Admin Creates Category
![image](https://github.com/framgia/sph-els-mark/assets/142192964/13e05998-8821-4622-8474-ba587279f13c)

- [x] Admin Delete Category
![image](https://github.com/framgia/sph-els-mark/assets/142192964/edf3043d-80b0-4efc-9c0a-db51eefeaec0)

- [x] If the user tries to edit the category 
![image](https://github.com/framgia/sph-els-mark/assets/142192964/04ceb197-d814-4e62-b5f5-3cfc5303b3c0)



</details>