### PR TITLE
[SELS-TASK] [BE]- Enable Authguards for the Category List endpoint 

### DIFF
--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -15,7 +15,8 @@ import { CreateCategoryDto } from './dto/category-create.dto';
 import { AddWordDto } from './dto/add-word.dto';
 import { WordsService } from './words.service';
 import { ChoicesService } from './choices.service';
-import { In } from 'typeorm';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Admin, In } from 'typeorm';
 import { AuthGuard } from 'src/auth/auth.guard';
 import { Request } from 'express';
 import { JwtService } from '@nestjs/jwt';
@@ -30,9 +31,17 @@ export class CategoriesController {
     private jwtService: JwtService,
     private userService: UserService,
   ) {}
-  // Reminder: Add authguard
+
+  @UseGuards(AuthGuard)
   @Get(['student/categories', 'admin/categories'])
-  async all() {
+  async all(@Body() body: CategoriesService, @Req() request: Request) {
+    const cookie = request.cookies['jwt'];
+    const { id: user_id } = await this.jwtService.verifyAsync(cookie);
+    const user = this.userService.findOne({ where: { user_id } });
+
+    if (!user) {
+      throw new NotFoundException('Forbidden Resource');
+    }
     return this.categoriesService.find({});
   }
   // Reminder: Add authguard

--- a/backend/src/categories/categories.module.ts
+++ b/backend/src/categories/categories.module.ts
@@ -11,6 +11,7 @@ import { JwtModule} from '@nestjs/jwt';
 import { User } from 'src/user/user';
 import { UserService } from 'src/user/user.service';
 
+
 @Module({
   imports: [JwtModule.register({
     secret: 'secret',


### PR DESCRIPTION
**Asana** 
- https://app.asana.com/0/1206099859473777/1206200787311538/f

**[Commands]**
- `docker compose up`

**[Pre-conditions]**
1.  After running the command , you can now access the Postman and Dbeaver.
2. Go to student/login, logged in
3. Go to student/categories
4. Go to admin/login, logged in
5. Go to admin/categories

**[Expected Output]**
 
- [x] Display Forbidden Resources if Student or Admin is not logged in
- [x] Display Categories on admin/categories if admin is logged in
- [x] Display Categories on student/categories if student is logged in


**[Screenshots]**

<details> 

-[x] Student or Admin accessing category without login

![Student-notIn-Category](https://github.com/framgia/sph-els-mark/assets/142192964/d94a8337-b1fe-4ee5-93c5-b49b4ed04d96)

![Admin-notIn-Category](https://github.com/framgia/sph-els-mark/assets/142192964/9e3b320f-0ad3-4524-966d-eb85260f31bc)

-[x] Student or Admin accessing category while logged in

![Student-loggedIn-Category](https://github.com/framgia/sph-els-mark/assets/142192964/0cb7c11e-3780-44bc-b9df-9c4bd377c345)

![Admin-loggedIn-Category](https://github.com/framgia/sph-els-mark/assets/142192964/f814d965-19df-412c-a0e5-df6f777f4599)


</details>

